### PR TITLE
Small improvements to REAMDE.md's Setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The default built ROM is mzm_us.gba
 - Install `binutils-arm-none-eabi` by running this command: `sudo apt install binutils-arm-none-eabi` or `sudo dnf install arm-none-eabi-binutils-cs`
 - Install `git` by running this command: `sudo apt install git` or `sudo dnf install git`
 - Install `make` by running this command: `sudo apt install make` or `sudo dnf install make`
-- Clone [agbcc](https://github.com/jiangzhengwenjz/agbcc) by running this command: `git clone https://github.com/jiangzhengwenjz/agbcc`
+- Clone [agbcc](https://github.com/jiangzhengwenjz/agbcc) by running this command: `git clone https://github.com/jiangzhengwenjz/agbcc.git`
 - Enter the agbcc folder (run `cd agbcc`) and build it (run `./build.sh`)
 - Either:
   - Install agbcc into this project (by using its `./install.sh <path>` script, where `<path>` is the path to the root of this repository), or

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The default built ROM is mzm_us.gba
 
 - **WINDOWS ONLY**: Install and setup [WSL](https://docs.microsoft.com/en-us/windows/wsl/install)
 - Run `sudo apt update` just in case
-- Install `binutils-arm-none-eabi` by running this command: `sudo apt-get install binutils-arm-none-eabi`
-- Install `git` by running this command: `sudo apt-get install git`
-- Install `make` by running this command: `sudo apt-get install make`
+- Install `binutils-arm-none-eabi` by running this command: `sudo apt install binutils-arm-none-eabi`
+- Install `git` by running this command: `sudo apt install git`
+- Install `make` by running this command: `sudo apt install make`
 - Clone [agbcc](https://github.com/jiangzhengwenjz/agbcc) by running this command: `git clone https://github.com/jiangzhengwenjz/agbcc`
 - Enter the agbcc folder (run `cd agbcc`) and build it (run `./build.sh`)
 - Either:

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The default built ROM is mzm_us.gba
 
 - **WINDOWS ONLY**: Install and setup [WSL](https://docs.microsoft.com/en-us/windows/wsl/install)
 - Run `sudo apt update` just in case
-- Install `binutils-arm-none-eabi` by running this command: `sudo apt install binutils-arm-none-eabi`
-- Install `git` by running this command: `sudo apt install git`
-- Install `make` by running this command: `sudo apt install make`
+- Install `binutils-arm-none-eabi` by running this command: `sudo apt install binutils-arm-none-eabi` or `sudo dnf install arm-none-eabi-binutils-cs`
+- Install `git` by running this command: `sudo apt install git` or `sudo dnf install git`
+- Install `make` by running this command: `sudo apt install make` or `sudo dnf install make`
 - Clone [agbcc](https://github.com/jiangzhengwenjz/agbcc) by running this command: `git clone https://github.com/jiangzhengwenjz/agbcc`
 - Enter the agbcc folder (run `cd agbcc`) and build it (run `./build.sh`)
 - Either:


### PR DESCRIPTION
- [x] I have read and understood the conditions outlined in [CONTRIBUTING.md](CONTRIBUTING.md)

This brings small changes to `README.md`:
- It replaces `apt-get` with `apt`.
- It adds `dnf` commands to the `apt` ones.
- It adds `.git` at the end of the agbcc repository in the cloning command.