### PR TITLE
Add the docs, serve and run rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/docs/doxygen/*
 /src/**/*.s
 /data/*
 /sound/direct_sound_samples/*

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,8 @@ ifeq ($(DATA),1)
 endif
 	$(MSG) RM linker.ld.pp
 	$Q$(RM) linker.ld.pp
+	$(MSG) RM docs/doxygen/
+	$Q$(RM) -r docs/doxygen
 
 .PHONY: help
 help:
@@ -280,3 +282,11 @@ jp_debug:
 # 	$(MAKE) REGION=cn
 # cn_debug:
 # 	$(MAKE) REGION=cn DEBUG=1
+
+.PHONY: docs
+docs:
+	doxygen
+
+.PHONY: serve
+serve:
+	python -m http.server 8080 -d docs/doxygen/html

--- a/Makefile
+++ b/Makefile
@@ -290,3 +290,21 @@ docs:
 .PHONY: serve
 serve:
 	python -m http.server 8080 -d docs/doxygen/html
+
+# Run the built target with mgba-qt.
+#
+# If host-spawn is available, this assumes to be in a build sandbox without
+# mgba-qt and use it to access mgba-qt out of the sandbox. Use mgba-qt if it is
+# available, otherwise try to run its Flatpak.
+.PHONY: run
+HOST_SPAWN := $(shell which host-spawn)
+run: $(TARGET)
+ifeq (, $(shell  $(HOST_SPAWN) which mgba-qt))
+ifeq (, $(shell  $(HOST_SPAWN) which flatpak))
+	$(error "No mgba-qt nor flatpak in $(PATH)")
+else
+	 $(HOST_SPAWN) flatpak run io.mgba.mGBA $<
+endif
+else
+	 $(HOST_SPAWN) mgba-qt $<
+endif


### PR DESCRIPTION
- [x] I have read and understood the conditions outlined in [CONTRIBUTING.md](CONTRIBUTING.md)

This adds the `docs` rule to build the documentation with Doxygen, the `serve` rule to serve the built documentation with Python, and the `run` rule to run the build target with mgba-qt. It also updates the clean rule and `.gitignore` to take the built documentation into account.